### PR TITLE
(untested) fix for trigger count bug in accession

### DIFF
--- a/ifcbdb/dashboard/accession.py
+++ b/ifcbdb/dashboard/accession.py
@@ -216,7 +216,7 @@ class Accession(object):
         b.ml_analyzed = ml_analyzed
         b.look_time = bin.look_time
         b.run_time = bin.run_time
-        b.n_triggers = len(bin)
+        b.n_triggers = bin.n_triggers
         if bin.pid.schema_version == SCHEMA_VERSION_1:
             ii = InfilledImages(bin)
             b.n_images = len(ii)


### PR DESCRIPTION
this fixes a bug where the number of triggers for each bin was computed as the number of lines in the ADC file rather than the trigger number on the last row of the ADC file (or zero if the ADC file has no rows)

This requires that `pyifcb` be updated to at least [this commit](https://github.com/joefutrelle/pyifcb/commit/86e4da6e6aa9ae9cb9ca9bbb79b88aef76bf232f)

This would close #337 

It has not been tested, so not ready to merge yet.

A utility for recomputing number of triggers for existing datasets in existing dashboards without a full resync should be provided as a separate PR.