### PR TITLE
version lock Django to below 4.2 to prevent breaking change requiring…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ifcbdb
 channels:
   - conda-forge
 dependencies:
-- django
+- django<4.2
 - gunicorn
 - psycopg2
 - pycrypto


### PR DESCRIPTION
… PostgreSQL 12.x