### PR TITLE
switch PostGIS container to use official image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - nginx_network
 
   postgres:
-    image: mdillon/postgis:11-alpine
+    image: postgis/postgis:11-3.3-alpine
     container_name: postgres
     environment:
       - POSTGRES_USER=ifcb


### PR DESCRIPTION
After using this new branch, the following command has to be run to install/update/fix some things related to PostGIS. This appears to be needed even though the version of PostgreSQL is the same - it may be tied to the different image versions

`docker-compose exec postgres update-postgis.sh`
 