### PR TITLE
Change pandas.to_timedelta y units to d (y is ambiguous)

### DIFF
--- a/ifcbdb/dashboard/models.py
+++ b/ifcbdb/dashboard/models.py
@@ -159,7 +159,7 @@ class Timeline(object):
                 resolution = 'bin'
             elif time_range < pd.Timedelta('60d'):
                 resolution = 'hour'
-            elif time_range < pd.Timedelta('3y'):
+            elif time_range < pd.Timedelta('1095d'): #3 years, pandas doesn't allow y units
                 resolution = 'day'
             else:
                 resolution = 'week'


### PR DESCRIPTION
In pandas 2.x 'M', 'Y', and 'y' units are no longer allowed because they are ambiguous. Change to days with a note.

https://pandas.pydata.org/docs/reference/api/pandas.to_timedelta.html