### PR TITLE
Include ifcbdb code in Dockerfile/image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ EXPOSE 8000
 # descend into app directory
 WORKDIR /ifcbdb
 
+COPY ./ifcbdb .
+
 CMD gunicorn --bind :8000 ifcbdb.wsgi:application --reload


### PR DESCRIPTION
Include the ifcbdb code in Dockerfile/generated
Docker image so that the image is usable outside
of the context of the code repo. Local code
can always be mounted into the Docker image
at /ifcbdb if desired.