### PR TITLE
Don't parse returned image coordinates from string

### DIFF
--- a/ifcbdb/assets/js/bin.js
+++ b/ifcbdb/assets/js/bin.js
@@ -538,7 +538,7 @@ function loadMosaic(pageNumber) {
     $.get(binDataUrl, function(data) {
 
         // Update the coordinates for the image
-        _coordinates = JSON.parse(data["coordinates"]);
+        _coordinates = data["coordinates"];
 
         // Indicate to the user that the mosaic is clickable
         $("#mosaic").css("cursor", "pointer");


### PR DESCRIPTION
Image coordinates appear to already be parsed here, and treating them as a string results in errors.

Not sure what is causing this difference, but I had to fix to get image mosaics working on a recent deployment.