### PR TITLE
Handle missing position

### DIFF
--- a/ifcbdb/dashboard/accession.py
+++ b/ifcbdb/dashboard/accession.py
@@ -217,7 +217,7 @@ class Accession(object):
             try:
                 latitude = float(latitude)
                 longitude = float(longitude)
-            except TypeError:
+            except (TypeError, ValueError):
                 latitude = None
                 longitude = None
             try:


### PR DESCRIPTION
When an instrument records the position as e.g. "N/A" i should be treated the same as None. The easiest way to do this is to except both TypeError and ValueError.