### PR TITLE
DRY in configuring dashboard and celery containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,25 @@
 version: '3'
 
+x-ifcb-common: &ifcb-common
+  image: ${IFCBDB_IMAGE:-whoi/ifcb-dashboard:4.3.0}
+  environment:
+    - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-changeme}
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-ifcb}
+  volumes:
+    - ${PRIMARY_DATA_DIR:-./ifcb_data}:/data
+    - ${LOCAL_SETTINGS:-/dev/null}:/ifcbdb/ifcbdb/local_settings.py
+  depends_on:
+    - postgres
+    - memcached
+    - redis
+  networks:
+    - postgres_network
+    - memcached_network
+    - redis_network
+
 services:
   ifcbdb:
-    image: ${IFCBDB_IMAGE:-whoi/ifcb-dashboard:4.3.0}
+    <<: *ifcb-common
     environment:
       - NGINX_HOST=${HOST:-localhost}
       - NGINX_HTTP_PORT=${HTTP_PORT:-80}
@@ -19,28 +36,10 @@ services:
       - postgres_network
       - memcached_network
       - redis_network
-    depends_on:
-      - postgres
-      - memcached
-      - redis
 
   celery:
-    image: ${IFCBDB_IMAGE:-whoi/ifcb-dashboard:4.3.0}
+    <<: *ifcb-common
     command: celery -A ifcbdb worker -l info
-    environment:
-      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-changeme}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-ifcb}
-    volumes:
-      - ${PRIMARY_DATA_DIR:-./ifcb_data}:/data
-      - ${LOCAL_SETTINGS:-/dev/null}:/ifcbdb/ifcbdb/local_settings.py
-    depends_on:
-      - postgres
-      - memcached
-      - redis
-    networks:
-      - redis_network
-      - postgres_network
-      - memcached_network
 
   nginx:
     image: ${NGINX_IMAGE:-nginx:1.25}


### PR DESCRIPTION
This refactoring uses a yaml anchor to consolidate several common configuration options between the celery and ifcbdb containers into a single place in the compose file. This should make it easier to maintain the compose file, especially for users with multiple volume mounts.