### PR TITLE
prevent output buffering to help with docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+ENV PYTHONUNBUFFERED=1
+
 # geospatial libraries
 RUN apt-get update && \
     apt-get install -y binutils git libproj-dev libgdal-dev libpoppler-dev && \


### PR DESCRIPTION
@joefutrelle I had this uncommitted for quite some time - figured it made sense just to add it. This helps to make sure that all output goes through docker immediately, so its easier to catch errors and other logging information