### PR TITLE
Fix rectangle packing bug in mosaic generation

### DIFF
--- a/ifcbdb/dashboard/mosaic.py
+++ b/ifcbdb/dashboard/mosaic.py
@@ -68,7 +68,7 @@ def join(x, y, w, h, xx, yy, ww, hh):
         # second rectangle contains the first one, return the second one
         return True, xx, yy, ww, hh
 
-    if not intersects(x, y, h, w, xx, yy, ww, hh):
+    if not intersects(x, y, w, h, xx, yy, ww, hh):
         # cannot join--not intersecting
         return False, x, y, w, h
 
@@ -192,6 +192,7 @@ class Packer(object):
             if fitness == DOESNT_FIT:
                 continue
             if min_fitness == DOESNT_FIT or fitness < min_fitness:
+                min_fitness = fitness
                 fittest_section = i
 
         return fittest_section


### PR DESCRIPTION
This PR fixes the rectangle packing algorithm to optimally place rectangles as it was originally intended. 

The changes are:
  * Fix intersection check to pass height and width in correct order.
  * Fix `select_fittest_section` to select the rectangle with the best fit, rather than the last fitting rectangle.

The rectangle packing will now be more condensed. An example result of the change:

<img width="1017" height="415" alt="rect_pack_bugfix" src="https://github.com/user-attachments/assets/a37332a4-f856-4e76-b6b8-bf374025e8b6" />
