### PR TITLE
fix truthiness check; safety check around bin count

### DIFF
--- a/ifcbdb/dashboard/models.py
+++ b/ifcbdb/dashboard/models.py
@@ -248,9 +248,15 @@ class Dataset(models.Model):
     attribution = models.CharField(max_length=512, blank=True)
     funding = models.CharField(max_length=512, blank=True)
 
+    # This model implements a __len__ method, which overrides the default truthiness behavior on an ORM
+    #   model. This normally returns True whether the model is saved or not in the database. The logic in
+    #   __len__ will override this, so defining __bool__ will retain the original behavior
+    def __bool__(self):
+        return True
+
     def __len__(self):
         # number of bins
-        return self.bins.count()
+        return self.bins.count() if self.pk else 0
 
     def data_volume(self):
         # total data volume in bytes


### PR DESCRIPTION
This PR corrects a few minor bugs that were not directly found in the wild, but could be an issue

- Fix exception through if the length of a dataset (which would be the number of bins) is called on a new dataset that does not have a backing data from the database (e.g., unsaved)
- Fixes an issue with conditional checks against a dataset. E.g., `True if dataset else False`. Because __len__ is defined, that is used as truthiness rather than the default on an ORM model, which is to just return True (whether the model is saved or not). The included __bool__ method takes precedence and both corrects the logic, and also prevents accidental usage of __len__ in a conditional statement that would make a database call that might not be expected