### PR TITLE
make cruise name into a link

### DIFF
--- a/ifcbdb/assets/js/bin.js
+++ b/ifcbdb/assets/js/bin.js
@@ -176,7 +176,18 @@ function updateBinStats(data) {
     $("#stat-trigger-freq").html(data["trigger_freq"]);
     $("#stat-ml-analyzed").html(data["ml_analyzed"]);
     $("#stat-concentration").html(data["concentration"]);
+
+
+    const dataset =  new URLSearchParams(window.location.search).get("dataset");
+    const cruiseParameters = {
+        cruise: data["cruise"],
+        bin: _bin,
+        ...(dataset && { dataset: dataset })
+    };
+
     $("#stat-cruise").html(data["cruise"]);
+    $("#stat-cruise-link").attr('href','/timeline?' + new URLSearchParams(cruiseParameters).toString());
+
     $("#stat-sample-type").html(data["sample_type"]);
     $("#stat-size").html(filesize.filesize(data["size"]));
     $("#stat-skip")

--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -526,7 +526,11 @@
                         <div class="flex-column">Depth: <span id="stat-depth"></span></div>
                       </div>
                       <div id="show-cruise" class="flex-row d-none">
-                        <div class="flex-column">Cruise: <span id="stat-cruise"></span></div>
+                        <div class="flex-column">Cruise:
+                            <a id="stat-cruise-link" href="#">
+                                <span id="stat-cruise"></span>
+                            </a>
+                        </div>
                       </div>
                       <div id="show-sample_type" class="flex-row d-none">
                         <div class="flex-column">Sample Type: <span id="stat-sample_type"></span></div>


### PR DESCRIPTION
This PR takes the cruise value shown on the bin details page and makes it a link to update the timeline (similar to how the instrument number field works). 

Unlike the instrument link, it will include the dataset parameter, assuming there is one to use. If a user goes directly to a bin by pasting a PID into the textbox in the nav, there is no dataset selected. In this scenario, the logic is currently set up to omit the dataset parameter. We can make other adjustments if there's something that works better for this scenario For instance, picking one of the datasets the bin is associated with, if any.