### PR TITLE
fix error on loading autocomplete library when user is not authenticated

### DIFF
--- a/ifcbdb/assets/js/bin.js
+++ b/ifcbdb/assets/js/bin.js
@@ -1190,6 +1190,10 @@ function initAutoComplete() {
         _autoCompleteJS.unInit();
     }
 
+    if (!document.querySelector("#tag-name")) {
+        return;
+    }
+    
     _autoCompleteJS = new autoComplete({
         selector: '#tag-name',
         placeHolder: "tag name",


### PR DESCRIPTION
This PR fixes a bug that was found when viewing a dataset w/o being authenticated. The UI to add tags will initialize an autocomplete library on the textbox used for entering in the name of the tag to add. This UI is only enabled when the user is logged in, so unauthenticated users were getting a javascript error

I've added a checked to ensure that textbox is in the DOM prior to initializing the library, preventing the error