### PR TITLE
fix bug replacing spaces in dataset name when there is no dataset

### DIFF
--- a/ifcbdb/dashboard/views.py
+++ b/ifcbdb/dashboard/views.py
@@ -80,7 +80,7 @@ def search_timeline_locations(request):
 
     # Replace spaces with forward slashes in the dataset name or the cache key will not be valid. We're using a
     #   character that is not a legal character within a dataset name
-    clean_dataset_name = dataset_name.replace(" ", "/")
+    clean_dataset_name = dataset_name.replace(" ", "/") if dataset_name else ""
 
     cache_key = 'tloc_b={};d={};t={};i={};c={};st={}'.format(bin_id, clean_dataset_name, tags, instrument_number, cruise, sample_type)
     cached = cache.get(cache_key)


### PR DESCRIPTION
This PR fixes an issue that was introduced in a prior fix that handled an error caused by datasets with spaces in the name. While that fix works in most cases, if a user goes to a dataset directly, there will be no dataset name. The bug was caused by still trying to sanitize the dataset name (for the cache key)