### PR TITLE
fix bins not appearing on bin page map

### DIFF
--- a/ifcbdb/assets/js/bin.js
+++ b/ifcbdb/assets/js/bin.js
@@ -794,7 +794,7 @@ function selectMapMarker(marker) {
     $("#no-bin-location").toggleClass("d-none", true);
 }
 
-function updateMapLocations(data, restrictToTimeline=false) {
+function updateMapLocations(data, restrictToTimeline=false, restrictToSelectedBin=false) {
     if (!_map) {
 
         var lat = defaultLat;
@@ -842,7 +842,7 @@ function updateMapLocations(data, restrictToTimeline=false) {
 
         // This event is needed to make the disabling of zoomToBoundsOnClick work properly. Without it, if clicking
         //   on the cluster would have normally spiderfied the cluster, it won't. This forces the spiderfy to happen
-        //   regarldess, making things work as a user would expect
+        //   regardless, making things work as a user would expect
         _markers.on('clusterclick', function (cluster) {
             cluster.layer.spiderfy();
         });
@@ -899,13 +899,20 @@ function updateMapLocations(data, restrictToTimeline=false) {
     }
 
     // If enabled, restrict the visible markers to just those bins that have a timestamp that is currently
-    //   visible on the timeline
-    const timelineLayout = $("#primary-plot-container")[0].layout;
-    if (timelineLayout && restrictToTimeline) {
-        const startUtc = getUtcDate(timelineLayout.xaxis.range[0]);
-        const endUtc = getUtcDate(timelineLayout.xaxis.range[1])
+    //   visible on the timeline. Since this relies on the timeline, there's additional checks to make sure
+    //   that the timeline layout (used to get the xaxis range) is on the page.
+    const plot = $("#primary-plot-container")[0];
+    if (plot && plot.layout && restrictToTimeline) {
+        const startUtc = getUtcDate(plot.layout.xaxis.range[0]);
+        const endUtc = getUtcDate(plot.layout.xaxis.range[1])
 
         _markerList = restrictMarkersToDateRange(_markerList, startUtc, endUtc);
+    }
+
+    // The selected bin is stored in _selectedMarkers, which means _markerList can be cleared out entirely if the
+    //   user only wants to see the selected bin on the map
+    if (restrictToSelectedBin) {
+        _markerList = [];
     }
 
     if (_markerList.length > 0) {

--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -445,20 +445,27 @@
 
                       <!-- Map Tap -->
                       <div id="map-tab-content" class="tab-pane py-2" role="tabpanel">
-                        <div class="card">
-                        <div class="card-body py-1">
-                          <div id="map-container" style="height:600px" ></div>
-                            <div id="no-bin-location" class="alert alert-warning text-center d-none">The selected bin does not have a latitude/longitude set</div>
-                            <label>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="limitMapToTimeline" checked>
-                                    <label class="form-check-label" for="limitMapToTimeline">
-                                        Limit bins on the map to those visible on the timeline
-                                    </label>
-                                </div>
-                            </label>
-                        </div>
-                      </div>
+                          <div class="card">
+                              <div class="card-body py-1">
+                                  <div id="map-container" style="height:600px"></div>
+                                  <div id="no-bin-location" class="alert alert-warning text-center d-none">
+                                      The selected bin does not have a latitude/longitude set
+                                  </div>
+                                  <div class="form-check">
+                                      {% if route == 'timeline' %}
+                                      <input class="form-check-input" type="checkbox" id="limitMapToTimeline" checked>
+                                      <label class="form-check-label" for="limitMapToTimeline">
+                                          Limit bins on the map to those visible on the timeline
+                                      </label>
+                                      {% else %}
+                                      <input class="form-check-input" type="checkbox" id="limitMapToSelectedBin">
+                                      <label class="form-check-label" for="limitMapToSelectedBin">
+                                          Show only this bin on the map
+                                      </label>
+                                      {% endif %}
+                                  </div>
+                              </div>
+                          </div>
                       </div>
                       <!--End Map Tab-->
                   </div>
@@ -1007,7 +1014,11 @@ function updateLocations() {
 }
 
 $("#limitMapToTimeline").on("change", function(e) {
-    updateMapLocations(_cachedLocationData, $(this).is(":checked"));
+    updateMapLocations(_cachedLocationData, $(this).is(":checked"), false);
+});
+
+$("#limitMapToSelectedBin").on("change", function(e) {
+    updateMapLocations(_cachedLocationData, false, $(this).is(":checked"));
 });
 
 function previewImage(img) {


### PR DESCRIPTION
This pull request resolves an issue @hsosik found on the bin page where the bin is not appearing on the map. This was a bug which is addressed in the PR, however, that lead to an additional question of what should appear on the map. Users navigating to the bin page from the timeline while have the selected dataset included in the url, so the default view of the map would include all bins from that dataset, with the bin the user is looking at highlighted in a different color. 

A reasonable alternative would be to show only that bin on the map and nothing else. To address this, I've added an option to show only the one bin on the map (unchecked by default) so the user has the choice. This also takes care of not showing the option to limit bins to the timeline, since on the bin page there is no timeline shown. 

The attached PR takes care of all of the above, but I can make some tweaks if a different UI would be more beneficial

Example map on the timeline page:
<img width="614" height="671" alt="image" src="https://github.com/user-attachments/assets/8f835cfe-dbd7-4918-aab5-11ebb763f654" />

Example map on the bin page:
<img width="628" height="666" alt="image" src="https://github.com/user-attachments/assets/a49bdcab-cf16-45ad-8fe0-98cd84997a95" />

