### PR TITLE
trucate team description to first line

### DIFF
--- a/ifcbdb/dashboard/templatetags/custom.py
+++ b/ifcbdb/dashboard/templatetags/custom.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def first_line(value):
+    if not value:
+        return ''
+
+    return value.split('\n')[0]

--- a/ifcbdb/templates/dashboard/datasets.html
+++ b/ifcbdb/templates/dashboard/datasets.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static waffle_tags %}
+{% load static waffle_tags custom %}
 {% block extra_head %}
 <title>IFCB dashboard</title>
 {% endblock %}
@@ -63,7 +63,7 @@
                         data-toggle="collapse" data-target="#collapse{{ forloop.counter }}"
                         aria-expanded="false" aria-controls="collapse{{ forloop.counter }}">
                     <span class="team-name">{{ team.name }}</span>
-                    {% if team.description %}<span class="team-description"> | {{ team.description }}</span>{% endif %}
+                    {% if team.description %}<span class="team-description"> | {{ team.description|first_line }}</span>{% endif %}
                 </button>
             </div>
             <div id="collapse{{ forloop.counter }}" class="{% if team_name != team.name %}collapse{% endif %}"


### PR DESCRIPTION
This PR restricts the team description, shown in the header of the accordion on the datasets page, to just the first line of text