### PR TITLE
Update Python libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==4.2.26
+django==4.2.28
 gunicorn==23.0.0
 psycopg2-binary==2.9.9
 numba==0.59.1
@@ -8,11 +8,11 @@ redis==5.0.3
 scipy==1.13.1
 pandas==2.2.3
 h5py==3.12.1
-requests==2.32.3
-Pillow==11.1.0
+requests==2.32.4
+Pillow==12.1.1
 rectpack==0.2.2
 scikit-image==0.24.0
 pysmb==1.2.10
 pyyaml==6.0.2
 django-waffle==5.0.0
-git+https://github.com/joefutrelle/pyifcb@v1.2.1
+git+https://github.com/joefutrelle/pyifcb@v1.3.0


### PR DESCRIPTION
This PR updates:
- pillow 11.1.0 -> 12.1.1
- django 4.2.26 -> 4.2.28
- requests 2.32.3 -> 2.32.4
- pyifcb 1.2.1 -> 1.3.0

This replaces a few separate dependabot pull requests and updates `pyifcb` to the latest version because some library versions must match `pyifcb`