### PR TITLE
add team filtering of criteria to bin management

### DIFF
--- a/ifcbdb/dashboard/models.py
+++ b/ifcbdb/dashboard/models.py
@@ -268,7 +268,10 @@ def bin_management_query(
             .distinct() \
             .values_list("name", flat=True)
 
-        team_names = list(set((team_names or []) + list(teams)))
+        if team_names is None:
+            team_names = teams
+        else:
+            team_names = [t for t in team_names if t in teams]
 
     # For the update query, we always want to avoid skipping any bins
     filter_skip = False

--- a/ifcbdb/secure/forms.py
+++ b/ifcbdb/secure/forms.py
@@ -2,6 +2,7 @@ import re, os
 from django import forms
 from django.contrib.auth.models import User, Group
 from django.core.exceptions import ValidationError
+import waffle
 
 from dashboard.models import Dataset, Instrument, DataDirectory, AppSettings, Tag, \
     Bin, Team, TeamUser, TeamDataset, \
@@ -398,38 +399,40 @@ class BinSearchForm(forms.Form):
     # FUTURE: Allow support for progressive filtering. E.g, changing dataset limits values for cruises
 
     input_classes = "form-control form-control-sm"
+    is_teams_enabled = waffle.switch_is_active("Teams")
 
     start_date = forms.DateField(
         required=False,
-        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}"}))
+        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}", "disabled": is_teams_enabled}))
     end_date = forms.DateField(
         required=False,
-        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}"}))
+        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}", "disabled": is_teams_enabled}))
+
+    # All dropdown based criteria are CharField's with a Select() width to allow for values to be
+    #   loaded after the page loads using a POST call. This enables the values to be limited to
+    #   just the team that's selected (if enabled). This removes the validation logic on those values,
+    #   but that is covered by the validation on the team, since that will restrict all results down
+    #   to just bins associated with a team the user has access to
     team = forms.ModelChoiceField(
         required=False,
-        queryset=None,
+        queryset=Team.objects.none(),
         empty_label=" ",
         widget=forms.Select(attrs={"class": input_classes}))
-    dataset = forms.ModelChoiceField(
+    dataset = forms.CharField(
         required=False,
-        queryset=None,
-        empty_label=" ",
-        widget=forms.Select(attrs={"class": input_classes}))
-    tag = forms.ModelChoiceField(
+        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+    tag = forms.CharField(
         required=False,
-        queryset=None,
-        empty_label=" ",
-        widget=forms.Select(attrs={"class": input_classes}))
-    cruise = forms.ChoiceField(
+        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+    cruise = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes}))
-    instrument = forms.ChoiceField(
+        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+    instrument = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes}))
-    sample_type = forms.ChoiceField(
+        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+    sample_type = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes}))
-
+        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user") if "user" in kwargs else None
@@ -470,42 +473,61 @@ class BinSearchForm(forms.Form):
 
         # Ensure the user has entered at least one piece of criteria to prevent searching through
         #   the entire database of bins
-        if not any(value not in [None, ""] for value in cleaned_data.values()):
+        values = [value for key, value in cleaned_data.items() if key != "team" and value not in [None, ""]]
+        if not any(values):
             raise ValidationError("Please select at least one thing to search for")
 
         # If both dates are entered, ensure end date is greater than or equal to start date
         if start_date is not None and end_date is not None and start_date >= end_date:
             raise ValidationError("End date cannot be earlier than the start date")
 
-    def build_cruise_choices(self, bins):
+    @staticmethod
+    def build_dataset_choices(bins):
+        datasets = Dataset.objects \
+            .filter(bins__in=bins) \
+            .distinct() \
+            .values_list("name", flat=True)
+
+        return [""] + list(datasets)
+
+    @staticmethod
+    def build_tag_choices(bins):
+        tags = Tag.objects \
+            .filter(tagevent__bin__in=bins) \
+            .distinct() \
+            .values_list("name", flat=True)
+
+        return [""] + list(tags)
+
+    @staticmethod
+    def build_cruise_choices(bins):
         cruises = bins \
             .exclude(cruise="") \
             .values_list("cruise", flat=True) \
             .order_by("cruise") \
             .distinct()
-        cruises = [""] + list(cruises)
 
-        return list(zip(cruises, cruises))
+        return [""] + list(cruises)
 
-    def build_instrument_choices(self, bins):
+    @staticmethod
+    def build_instrument_choices(bins):
         instruments = bins \
             .values_list("instrument__number", flat=True) \
             .order_by("instrument__number") \
             .distinct()
-        instruments = [""] + [f"IFCB{instrument_number}" for instrument_number in instruments]
+        instrument_choices = [f"IFCB{instrument_number}" for instrument_number in instruments]
 
-        return list(zip(instruments, instruments))
+        return [""] + instrument_choices
 
-    def build_sample_type_choices(self, bins):
+    @staticmethod
+    def build_sample_type_choices(bins):
         sample_types = bins \
             .exclude(sample_type="") \
             .values_list("sample_type", flat=True) \
             .order_by("sample_type") \
             .distinct()
-        sample_types = [""] + list(sample_types)
 
-        return list(zip(sample_types, sample_types))
-
+        return [""] + list(sample_types)
 
 class BinActionForm(forms.Form):
     input_classes = "form-control form-control-sm"

--- a/ifcbdb/secure/forms.py
+++ b/ifcbdb/secure/forms.py
@@ -399,14 +399,13 @@ class BinSearchForm(forms.Form):
     # FUTURE: Allow support for progressive filtering. E.g, changing dataset limits values for cruises
 
     input_classes = "form-control form-control-sm"
-    is_teams_enabled = waffle.switch_is_active("Teams")
 
     start_date = forms.DateField(
         required=False,
-        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}", "disabled": is_teams_enabled}))
+        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}",}))
     end_date = forms.DateField(
         required=False,
-        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}", "disabled": is_teams_enabled}))
+        widget=forms.TextInput(attrs={"class": f"date-picker {input_classes}",}))
 
     # All dropdown based criteria are CharField's with a Select() width to allow for values to be
     #   loaded after the page loads using a POST call. This enables the values to be limited to
@@ -420,24 +419,26 @@ class BinSearchForm(forms.Form):
         widget=forms.Select(attrs={"class": input_classes}))
     dataset = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+        widget=forms.Select(attrs={"class": input_classes}))
     tag = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+        widget=forms.Select(attrs={"class": input_classes}))
     cruise = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+        widget=forms.Select(attrs={"class": input_classes}))
     instrument = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+        widget=forms.Select(attrs={"class": input_classes}))
     sample_type = forms.CharField(
         required=False,
-        widget=forms.Select(attrs={"class": input_classes, "disabled": is_teams_enabled}))
+        widget=forms.Select(attrs={"class": input_classes}))
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user") if "user" in kwargs else None
 
         super().__init__(*args, **kwargs)
+
+        is_teams_enabled = waffle.switch_is_active("Teams")
 
         # TODO: Should we be filtering down the list of tags?
         tags = Tag.objects.all()
@@ -461,10 +462,17 @@ class BinSearchForm(forms.Form):
 
         self.fields["team"].queryset = teams.order_by("name")
         self.fields["dataset"].queryset = datasets.order_by("name")
+        self.fields["dataset"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["instrument"].choices = self.build_instrument_choices(bins)
+        self.fields["instrument"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["tag"].queryset = tags.order_by("name")
+        self.fields["tag"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["cruise"].choices = self.build_cruise_choices(bins)
+        self.fields["cruise"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["sample_type"].choices = self.build_sample_type_choices(bins)
+        self.fields["sample_type"].widget.attrs["disabled"] = is_teams_enabled
+        self.fields["start_date"].widget.attrs["disabled"] = is_teams_enabled
+        self.fields["end_date"].widget.attrs["disabled"] = is_teams_enabled
 
     def clean(self):
         cleaned_data = self.cleaned_data

--- a/ifcbdb/secure/forms.py
+++ b/ifcbdb/secure/forms.py
@@ -439,37 +439,13 @@ class BinSearchForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         is_teams_enabled = waffle.switch_is_active("Teams")
-
-        # TODO: Should we be filtering down the list of tags?
-        tags = Tag.objects.all()
-
-        datasets = Dataset.objects.exclude(is_active=False)
         teams = auth.get_associated_teams(user)
 
-        # Anyone that is not a staff or super admin will need their list of teams and datasets filtered down to just
-        #   what they have access to. This also then carries through to which bins they are able to manage
-        if not auth.has_admin_access(user):
-            dataset_ids = TeamDataset.objects \
-                .filter(team__in=teams) \
-                .values_list("dataset_id", flat=True)
-
-            datasets = datasets.filter(id__in=dataset_ids)
-
-        # Bins, restricted down to just those for the user's team if they are not a superadmin
-        bins = Bin.objects.all()
-        if not user.is_superuser:
-            bins = bins.filter(team__in=teams)
-
         self.fields["team"].queryset = teams.order_by("name")
-        self.fields["dataset"].queryset = datasets.order_by("name")
         self.fields["dataset"].widget.attrs["disabled"] = is_teams_enabled
-        self.fields["instrument"].choices = self.build_instrument_choices(bins)
         self.fields["instrument"].widget.attrs["disabled"] = is_teams_enabled
-        self.fields["tag"].queryset = tags.order_by("name")
         self.fields["tag"].widget.attrs["disabled"] = is_teams_enabled
-        self.fields["cruise"].choices = self.build_cruise_choices(bins)
         self.fields["cruise"].widget.attrs["disabled"] = is_teams_enabled
-        self.fields["sample_type"].choices = self.build_sample_type_choices(bins)
         self.fields["sample_type"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["start_date"].widget.attrs["disabled"] = is_teams_enabled
         self.fields["end_date"].widget.attrs["disabled"] = is_teams_enabled

--- a/ifcbdb/secure/urls.py
+++ b/ifcbdb/secure/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('edit-directory/<int:dataset_id>/<int:id>', views.edit_directory, name='edit-directory'),
     path('app-settings', views.app_settings, name='app-settings'),
     path('bin-management', views.bin_management, name='bin-management'),
+    path('bin-management/criteria', views.bin_management_criteria, name='bin-management-criteria'),
     path('bin-management/search', views.bin_management_search, name='bin-management-search'),
     path('bin-management/export', views.bin_management_export, name='bin-management-export'),
     path('bin-management/execute', views.bin_management_execute, name='bin-management-execute'),

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -966,6 +966,9 @@ def bin_management(request):
 @login_required
 @require_POST
 def bin_management_criteria(request):
+    if not auth.can_manage_bins(request.user):
+        return redirect(reverse("secure:index"))
+
     team_id = request.POST.get("team")
     team = get_object_or_404(Team, pk=team_id)
 

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -25,6 +25,7 @@ from common.constants import Features, TeamRoles, BinManagementActions, BIN_ID_C
 
 from django.core.cache import cache
 from celery.result import AsyncResult
+import waffle
 from waffle.decorators import waffle_switch
 
 
@@ -944,11 +945,51 @@ def bin_management(request):
     #  elements and pre-render them before a search is run
     action_form = BinActionForm(user=request.user)
 
+    # Additional criteria on page load is only needed when the teams feature is not enabled. When it is, the data will
+    #  be populated after the user selects a team in the UI
+    criteria = {}
+    if not waffle.switch_is_active("Teams"):
+        bins = Bin.objects.all()
+
+        criteria["datasets"] =  BinSearchForm.build_dataset_choices(bins)
+        criteria["instruments"] = BinSearchForm.build_instrument_choices(bins)
+        criteria["cruises"] = BinSearchForm.build_cruise_choices(bins)
+        criteria["sample_types"] = BinSearchForm.build_sample_type_choices(bins)
+        criteria["tags"] = BinSearchForm.build_tag_choices(bins)
+
     return render(request, 'secure/bin-management.html', {
         "form": form,
         "action_form": action_form,
+        **criteria,
     })
 
+@login_required
+@require_POST
+def bin_management_criteria(request):
+    team_id = request.POST.get("team")
+    team = get_object_or_404(Team, pk=team_id)
+
+    # Ensure non-admins have selected a team they are associated with
+    if not auth.is_admin(request.user):
+        teams = auth.get_associated_teams(request.user)
+        if not team in teams:
+            return HttpResponseForbidden()
+
+    bins = Bin.objects.filter(team=team)
+
+    datasets =  BinSearchForm.build_dataset_choices(bins)
+    instruments = BinSearchForm.build_instrument_choices(bins)
+    cruises = BinSearchForm.build_cruise_choices(bins)
+    sample_types = BinSearchForm.build_sample_type_choices(bins)
+    tags = BinSearchForm.build_tag_choices(bins)
+
+    return JsonResponse({
+        "datasets": datasets,
+        "instruments": instruments,
+        "cruises": cruises,
+        "sample_types": sample_types,
+        "tags": tags,
+    })
 
 @login_required
 @require_POST
@@ -986,11 +1027,7 @@ def bin_management_export(request, dataset_name=None):
         })
 
     bin_qs = build_bin_query_from_form_data(request.user, form)
-
-    # TODO: We're not supplying a dataset name. The benefit of that would be defaulting the location and depth values
-    #   in the export. Not sure if that is good here since the goal of this export is partially to re-import?
     df = export_metadata(None, bin_qs)
-
     filename = 'bins.csv'
 
     csv_buf = BytesIO()
@@ -1054,13 +1091,13 @@ def build_bin_query_from_form_data(user, form):
     cruise = form.cleaned_data.get("cruise")
     sample_type = form.cleaned_data.get("sample_type")
     tag = form.cleaned_data.get("tag")
-    tags = [tag.name] if tag else []
+    tags = [tag] if tag else []
 
     return bin_management_query(
         user,
         start=start_date,
         end=end_date,
-        dataset_name=dataset.name if dataset is not None else None,
+        dataset_name=dataset,
         instrument_number=request_get_instrument(instrument),
         tags=tags,
         cruise=cruise,

--- a/ifcbdb/templates/secure/bin-management.html
+++ b/ifcbdb/templates/secure/bin-management.html
@@ -377,6 +377,12 @@
 
         function changeTeam() {
             if (!$("[name=team]").val().length) {
+               fillDropdown("[name=dataset]", []);
+               fillDropdown("[name=instrument]", []);
+               fillDropdown("[name=cruise]", []);
+               fillDropdown("[name=sample_type]", []);
+               fillDropdown("[name=tag]", []);
+
                 enableSearchForm(true);
                 return;
             }
@@ -395,11 +401,26 @@
             });
         }
 
+        function fillDropdown(selector, values) {
+            const dropdown = $(selector);
+
+            const currentValue = dropdown.val();
+
+            dropdown.empty();
+
+            $.each(values, function(index, item) {
+                dropdown.append($('<option></option>').val(item).text(item));
+            });
+
+            dropdown.val(currentValue);
+        }
+
         {% switch 'Teams' %}
 
         const teamOptions = $("[name=team] option");
         if (teamOptions.length === 2) {
             teamOptions.get(1).selected = true;
+            changeTeam();
         }
 
         {% else %}
@@ -419,18 +440,6 @@
         {% endswitch %}
     });
 
-    function fillDropdown(selector, values) {
-        const dropdown = $(selector);
 
-        const currentValue = dropdown.val();
-
-        dropdown.empty();
-
-        $.each(values, function(index, item) {
-            dropdown.append($('<option></option>').val(item).text(item));
-        });
-
-        dropdown.val(currentValue);
-    }
 </script>
 {% endblock %}

--- a/ifcbdb/templates/secure/bin-management.html
+++ b/ifcbdb/templates/secure/bin-management.html
@@ -24,6 +24,7 @@
                         {{ form.team }}
                     </div>
                 </div>
+                <hr />
                 {% endswitch %}
                 <div class="form-row mb-2">
                     <div class="col-md-4">Dataset</div>
@@ -155,7 +156,17 @@
 
 {% endblock %} {% block scripts %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.10.0/js/bootstrap-datepicker.min.js" integrity="sha512-LsnSViqQyaXpD4mBBdRYeP6sRwJiJveh2ZIbW41EBrNmKxgr/LFZIiWT6yr+nycvhvauz8c2nYMhrP80YhG7Cw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+{% switch 'Teams' %}
+{% else %}
+    {{ datasets|json_script:"dataset-choices" }}
+    {{ instruments|json_script:"instrument-choices" }}
+    {{ cruises|json_script:"cruise-choices" }}
+    {{ sample_types|json_script:"sample-type-choices" }}
+    {{ tags|json_script:"tag-choices" }}
+{% endswitch %}
 <script>
+
+
     $(function(){
         const AssignDatasetAction = "assign-dataset";
         const UnassignDatasetAction = "unassign-dataset";
@@ -193,6 +204,10 @@
         $("input[name=action]").on("change", function(e) {
             changeAction();
         });
+
+        $("select[name=team]").on("change", function(e) {
+            changeTeam();
+        })
 
         function search() {
             toggleSearchErrors(false);
@@ -251,8 +266,23 @@
         }
 
         function enableSearchForm(isEnabled) {
+            let isCriteriaEnabled = isEnabled;
+
+            {% switch 'Teams' %}
+            isCriteriaEnabled = isCriteriaEnabled && $("select[name=team]").val() !== "";
+            {% endswitch %}
+
             $("#search-form input[type=text], #search-form select").each(function() {
-                $(this).prop("disabled", !isEnabled);
+                const name = $(this).attr("name");
+
+                {% switch 'Teams' %}
+                if (name === "team") {
+                    $(this).prop("disabled", !isEnabled);
+                    return;
+                }
+                {% endswitch %}
+
+                $(this).prop("disabled", !isCriteriaEnabled);
             });
 
             $("#search-button").toggleClass("invisible", !isEnabled);
@@ -344,6 +374,63 @@
             $("[name=assigned_dataset]").prop("disabled", action !== AssignDatasetAction);
             $("[name=unassigned_dataset]").prop("disabled", action !== UnassignDatasetAction);
         }
+
+        function changeTeam() {
+            if (!$("[name=team]").val().length) {
+                enableSearchForm(true);
+                return;
+            }
+
+            const searchForm = $("#search-form");
+            const searchFormData = searchForm.serializeArray();
+
+           $.post("/secure/bin-management/criteria", searchFormData, function(data) {
+               fillDropdown("[name=dataset]", data.datasets || []);
+               fillDropdown("[name=instrument]", data.instruments || []);
+               fillDropdown("[name=cruise]", data.cruises || []);
+               fillDropdown("[name=sample_type]", data.sample_types || []);
+               fillDropdown("[name=tag]", data.tags || []);
+
+               enableSearchForm(true);
+            });
+        }
+
+        {% switch 'Teams' %}
+
+        const teamOptions = $("[name=team] option");
+        if (teamOptions.length === 2) {
+            teamOptions.get(1).selected = true;
+        }
+
+        {% else %}
+
+        const datasetChoices = JSON.parse(document.getElementById('dataset-choices').textContent);
+        const instrumentChoices = JSON.parse(document.getElementById('instrument-choices').textContent);
+        const cruiseChoices = JSON.parse(document.getElementById('cruise-choices').textContent);
+        const sampleTypeChoices = JSON.parse(document.getElementById('sample-type-choices').textContent);
+        const tagChoices = JSON.parse(document.getElementById('tag-choices').textContent);
+
+        fillDropdown("[name=dataset]", datasetChoices || []);
+        fillDropdown("[name=instrument]", instrumentChoices || []);
+        fillDropdown("[name=cruise]", cruiseChoices || []);
+        fillDropdown("[name=sample_type]", sampleTypeChoices || []);
+        fillDropdown("[name=tag]", tagChoices || []);
+
+        {% endswitch %}
     });
+
+    function fillDropdown(selector, values) {
+        const dropdown = $(selector);
+
+        const currentValue = dropdown.val();
+
+        dropdown.empty();
+
+        $.each(values, function(index, item) {
+            dropdown.append($('<option></option>').val(item).text(item));
+        });
+
+        dropdown.val(currentValue);
+    }
 </script>
 {% endblock %}


### PR DESCRIPTION
This PR adds team filtering to the criteria on the bin management page. When the teams feature is enabled, all criteria except the team will be disabled until you select a team. Once you do, those criteria fields will become enabled and the dropdowns (instrument, cruise, etc) will be filtered down to just those from bins associated with the selected team. When the teams feature is not enabled, it works how it did before where there is no team dropdown, and all criteria is visible and the values are pulled from all bins

<img width="760" height="613" alt="image" src="https://github.com/user-attachments/assets/e3fa4f53-f96b-4bee-8c91-4b6bf0f91ddc" />
