### PR TITLE
handle quotes in a datasets title

### DIFF
--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -1421,7 +1421,7 @@ $(function() {
     })
 
     var title = "";
-    {% if dataset %}title += " » {{ dataset.title }}";{% endif %}
+    {% if dataset %}title += " » {{ dataset.title|escapejs }}";{% endif %}
     {% if instrument %}title += " » IFCB{{ instrument.number }}";{% endif %}
     {% if cruise %}title += " » {{ cruise }}"{% endif %}
         {% if sample_type %}title += " » {{ sample_type }}"{% endif %}


### PR DESCRIPTION
If a dataset has an apostrophe in it, the page title renders with special characters

<img width="307" height="59" alt="image" src="https://github.com/user-attachments/assets/e063b7e6-cecd-4f89-b7aa-f6379f4a9df8" />

This PR escapes those characters so it renders properly