### PR TITLE
Metadata commands

### DIFF
--- a/ifcbdb/common/constants.py
+++ b/ifcbdb/common/constants.py
@@ -18,3 +18,5 @@ class BinManagementActions(Enum):
 
 # Metadata column names
 BIN_ID_COLUMNS = ['id','pid','lid','bin','bin_id','sample','sample_id','filename']
+ADD_DATASET_COLUMNS = ['add_dataset', 'adddataset']
+REMOVE_DATASET_COLUMNS = ['remove_dataset', 'removedataset', 'delete_dataset', 'deletedataset']

--- a/ifcbdb/dashboard/accession.py
+++ b/ifcbdb/dashboard/accession.py
@@ -479,8 +479,6 @@ def import_metadata(metadata_dataframe, progress_callback=do_nothing):
 
             # command columns
 
-            # TODO: the dataset being added or removed must be accessible by the user (for non-admins)
-
             if add_dataset_col is not None:
                 dataset_name = get_cell(row, add_dataset_col)
                 if str(dataset_name or "").strip():

--- a/ifcbdb/dashboard/accession.py
+++ b/ifcbdb/dashboard/accession.py
@@ -13,7 +13,8 @@ from django.contrib.postgres.aggregates.general import StringAgg
 import pandas as pd
 import numpy as np
 
-from .models import Bin, DataDirectory, Instrument, Timeline, Dataset, normalize_tag_name, Team, TeamDataset
+from .models import Bin, DataDirectory, Instrument, Timeline, Dataset, Tag, TagEvent, \
+    normalize_tag_name, Team, TeamDataset
 from .qaqc import check_bad, check_no_rois
 
 import ifcb
@@ -312,6 +313,10 @@ def import_metadata(metadata_dataframe, progress_callback=do_nothing):
     CAST_COLUMNS = ['cast']
     NISKIN_COLUMNS = ['niskin','bottle']
     SAMPLE_TYPE_COLUMNS = ['sampletype','sample_type']
+    ADD_DATASET_COLUMNS = ['add_dataset', 'adddataset']
+    REMOVE_DATASET_COLUMNS = ['remove_dataset', 'removedataset', 'delete_dataset', 'deletedataset']
+    ADD_TAG_COLUMNS = ['add_tag', 'addtag']
+    REMOVE_TAG_COLUMNS = ['remove_tag', 'removetag', 'delete_tag', 'deletetag']
 
     SKIP_POSITIVE_VALUES = ['skip','yes','y','true','t','1']
     SKIP_NEGATIVE_VALUES = ['noskip','no','n','false','f','0']
@@ -360,6 +365,11 @@ def import_metadata(metadata_dataframe, progress_callback=do_nothing):
     niskin_col = get_column(df, NISKIN_COLUMNS)
 
     sample_type_col = get_column(df, SAMPLE_TYPE_COLUMNS)
+
+    add_dataset_col = get_column(df, ADD_DATASET_COLUMNS)
+    remove_dataset_col = get_column(df, REMOVE_DATASET_COLUMNS)
+    add_tag_col = get_column(df, ADD_TAG_COLUMNS)
+    remove_tag_col = get_column(df, REMOVE_TAG_COLUMNS)
 
     tag_cols = []
     for c in df.columns:
@@ -466,6 +476,45 @@ def import_metadata(metadata_dataframe, progress_callback=do_nothing):
                 body = get_cell(row, comments_col)
                 if body is not None:
                     b.add_comment(body, skip_duplicates=True)
+
+            # command columns
+
+            # TODO: the dataset being added or removed must be accessible by the user (for non-admins)
+
+            if add_dataset_col is not None:
+                dataset_name = get_cell(row, add_dataset_col)
+                if str(dataset_name or "").strip():
+                    try:
+                        dataset = Dataset.objects.get(name__iexact=dataset_name)
+                        b.datasets.add(dataset)
+                    except Dataset.DoesNotExist:
+                        raise ValueError(f"Dataset '{dataset_name}' not found for {add_dataset_col}")
+
+            if remove_dataset_col is not None:
+                dataset_name = get_cell(row, remove_dataset_col)
+                if str(dataset_name or "").strip():
+                    try:
+                        dataset = Dataset.objects.get(name__iexact=dataset_name)
+                        b.datasets.remove(dataset)
+                    except Dataset.DoesNotExist:
+                        pass
+
+            if add_tag_col is not None:
+                tag = get_cell(row, add_tag_col)
+                if str(tag or "").strip():
+                    if re.match(r"^[0-9\.]+$", str(tag)):
+                        raise ValueError(f"tag '{tag}' consists of only digits")
+                    normalized = normalize_tag_name(str(tag))
+                    b.add_tag(normalized)
+
+            if remove_tag_col is not None:
+                tag = get_cell(row, remove_tag_col)
+                if str(tag or "").strip():
+                    normalized = normalize_tag_name(str(tag))
+                    try:
+                        b.delete_tag(normalized)
+                    except (Tag.DoesNotExist, TagEvent.DoesNotExist):
+                        pass
 
             # skip flag
 
@@ -597,6 +646,10 @@ def export_metadata(ds, bins):
         r['comment_summary'].append(comment_summary_by_id.get(item['id'], ''))
         r['trigger_selection'].append(trigger_selection_by_id.get(item['id'], ''))
         r['skip'].append(1 if item['skip'] else 0)
+        r['add_dataset'].append('')
+        r['remove_dataset'].append('')
+        r['add_tag'].append('')
+        r['remove_tag'].append('')
 
     df = pd.DataFrame(r)
 

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -20,7 +20,7 @@ from .forms import DatasetForm, InstrumentForm, DirectoryForm, MetadataUploadFor
 
 from dashboard.accession import export_metadata
 from common import auth
-from common.constants import Features, TeamRoles, BinManagementActions, BIN_ID_COLUMNS
+from common.constants import Features, TeamRoles, BinManagementActions, BIN_ID_COLUMNS, ADD_DATASET_COLUMNS, REMOVE_DATASET_COLUMNS
 
 
 from django.core.cache import cache
@@ -869,6 +869,27 @@ def upload_metadata(request):
                 bins_ids = list(bins_ids)
 
                 df = df[df[pid_col].isin(bins_ids)]
+
+                # Blank out any dataset names that are not associated with the user uploading the data to
+                #   ensure they cannot assign or unassign bins to datasets they are not privy to
+                add_dataset_col = get_column(df, ADD_DATASET_COLUMNS)
+                remove_dataset_col = get_column(df, REMOVE_DATASET_COLUMNS)
+
+                if add_dataset_col is not None or remove_dataset_col is not None:
+                    valid_dataset_names = auth \
+                        .get_associated_datasets(request.user) \
+                        .values_list("name", flat=True)
+
+                    if add_dataset_col is not None:
+                        df[add_dataset_col] = df[add_dataset_col].apply(
+                            lambda x: x if pd.isna(x) or str(x).strip() in valid_dataset_names else ""
+                        )
+
+                    if remove_dataset_col is not None:
+                        df[remove_dataset_col] = df[remove_dataset_col].apply(
+                            lambda x: x if pd.isna(x) or str(x).strip() in valid_dataset_names else ""
+                        )
+
                 json_df = df.to_json()
 
             added = cache.add(METADATA_UPLOAD_LOCK_KEY, True, timeout=None) # this is atomic

--- a/ifcbdb/templates/secure/upload-metadata.html
+++ b/ifcbdb/templates/secure/upload-metadata.html
@@ -49,6 +49,22 @@
                         <div class="form-group">
                             <input id="submit" type="submit" value="Upload" class="btn btn-sm btn-mdb-color" />
                         </div>
+                        <div class="form-group mt-4">
+                            <small class="text-muted">
+                                <strong>Supported Columns:</strong>
+                                <ul class="mb-0 pl-3">
+                                    <li><strong>Bin ID:</strong> id, pid, lid, bin, bin_id, sample, sample_id, filename</li>
+                                    <li><strong>Location:</strong> latitude/lat/y, longitude/lon/lng/x</li>
+                                    <li><strong>Timestamp:</strong> date, timestamp, datetime</li>
+                                    <li><strong>Depth:</strong> depth, dep, z</li>
+                                    <li><strong>Comments:</strong> comment, comments, note, notes</li>
+                                    <li><strong>Sample Info:</strong> cruise, cast, niskin/bottle, sampletype/sample_type</li>
+                                    <li><strong>Tags:</strong> tag*, add_tag, remove_tag (or addtag/removetag/deletetag)</li>
+                                    <li><strong>Datasets:</strong> add_dataset, remove_dataset (or adddataset/removedataset/deletedataset)</li>
+                                    <li><strong>Other:</strong> ml_analyzed, skip</li>
+                                </ul>
+                            </small>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/ifcbdb/templates/secure/upload-metadata.html
+++ b/ifcbdb/templates/secure/upload-metadata.html
@@ -58,9 +58,9 @@
                                     <li><strong>Timestamp:</strong> date, timestamp, datetime</li>
                                     <li><strong>Depth:</strong> depth, dep, z</li>
                                     <li><strong>Comments:</strong> comment, comments, note, notes</li>
-                                    <li><strong>Sample Info:</strong> cruise, cast, niskin/bottle, sampletype/sample_type</li>
-                                    <li><strong>Tags:</strong> tag*, add_tag, remove_tag (or addtag/removetag/deletetag)</li>
-                                    <li><strong>Datasets:</strong> add_dataset, remove_dataset (or adddataset/removedataset/deletedataset)</li>
+                                    <li><strong>Sample Info:</strong> cruise, cast, niskin, bottle, sample_type</li>
+                                    <li><strong>Tags:</strong> tag*, add_tag, remove_tag</li>
+                                    <li><strong>Datasets:</strong> add_dataset, remove_dataset</li>
                                     <li><strong>Other:</strong> ml_analyzed, skip</li>
                                 </ul>
                             </small>


### PR DESCRIPTION
This PR adds 4 "commands" to the metadata import: add_dataset, remove_dataset, add_tag, remove_tag

1. The commands work with or without the underscore, and with "delete" as an alternative to "remove"
2. Attempting to add a dataset that does not exist throws an error for that row
3. Removing a tag or dataset that is not already associated with that bin will ignore it silently
4. There are checks in place for non-super admins (team captains) to ensure the dataset they want to add or remove is one they have access to. If not, all other data will be applied but not the dataset specified
5. Added some helper text to the import screen with what columns are available
6. Added these new columns to the export of metadata information

<img width="1168" height="575" alt="vmware_kxPUvLDsyZ" src="https://github.com/user-attachments/assets/b08fc566-d7f2-44b4-b598-97328f3a2ecf" />
