### PR TITLE
Wrap export metadata fields with quotes

### DIFF
--- a/ifcbdb/dashboard/views.py
+++ b/ifcbdb/dashboard/views.py
@@ -1,6 +1,7 @@
 import json
 import re
 from io import BytesIO
+import csv
 
 import numpy as np
 import pandas as pd
@@ -95,7 +96,7 @@ def bin_in_dataset_or_404(bin, dataset):
 
 def dataframe_csv_response(df, **kw):
     csv_buf = BytesIO()
-    df.to_csv(csv_buf, mode='wb', **kw)
+    df.to_csv(csv_buf, mode="wb", quoting=csv.QUOTE_NONNUMERIC, **kw)
     csv_buf.seek(0)
     response = StreamingHttpResponse(csv_buf, content_type='text/csv')
     return response

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -1,4 +1,5 @@
 import json
+import csv
 from io import BytesIO
 from itertools import groupby
 from operator import attrgetter
@@ -1034,7 +1035,7 @@ def bin_management_export(request, dataset_name=None):
     filename = 'bins.csv'
 
     csv_buf = BytesIO()
-    df.to_csv(csv_buf, mode='wb', index=None)
+    df.to_csv(csv_buf, mode='wb', quoting=csv.QUOTE_NONNUMERIC, index=None)
     csv_buf.seek(0)
 
     response = StreamingHttpResponse(csv_buf, content_type='text/csv')


### PR DESCRIPTION
While working on another task, the export metadata was generated a CSV with bad data. This was because of text I had within the comment_summary column containing a semicolon. That split the column in two, which shifted the remaining columns over

This PR changes the CSV export to wrap non-numeric fields with quotes, which fixes the formatting issues