### PR TITLE
Add team to breadcrumb on the bin page

### DIFF
--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -114,6 +114,10 @@
     <div class="row d-flex justify-content-between">
       <div class="pl-3">
         <span class="h3-responsive">
+            {% if team %}
+                <a href="{% url 'datasets' team.name %}">{{ team.name }}</a> »
+            {% endif %}
+
             {% if dataset %}
               <a href="timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
                 {{ dataset.title }}


### PR DESCRIPTION
This PR adds the team name (which is linked) to the bin page breadcrumb. The timeline was already set up to include `team >> dataset`. This update just continues the same patter, making the bin page `team >> dataset >> bin`

<img width="669" height="242" alt="vmware_BfEmJAJBWg" src="https://github.com/user-attachments/assets/688bd8d0-428b-4a86-94b8-37010e66ccd8" />
