### PR TITLE
Include accession time in bin details

### DIFF
--- a/ifcbdb/dashboard/views.py
+++ b/ifcbdb/dashboard/views.py
@@ -881,6 +881,7 @@ def _bin_details(bin, dataset=None, view_size=None, scale_factor=None, preload_a
         "cruise": bin.cruise,
         "cast": bin.cast,
         "niskin": bin.niskin,
+        "accession_time_iso": bin.added.isoformat(),
     }
 
 def _mosaic_page_image(request, bin_id):


### PR DESCRIPTION
Include accession time (`added`) in bin details returned by the API (`/api/bin/<bin id>`). This is useful for determining the lag time between bin accession and the production of postprocessed files (blobs/features/autoclass).