### PR TITLE
allow managers to manage tags and the skip flag

### DIFF
--- a/ifcbdb/assets/js/bin.js
+++ b/ifcbdb/assets/js/bin.js
@@ -406,7 +406,7 @@ function displayTags(tags) {
 
         li.append(span);
 
-        if (_userId != null) {
+        if (_userId != null && $("#add-tag").length) {
             li.append(remove);
             remove.append(icon);
         }
@@ -813,6 +813,10 @@ function recenterMap() {
 }
 
 function selectMapMarker(marker) {
+    if (!marker) {
+        return;
+    }
+
     // TODO: Make sure zooming to layer is no longer required (might have only been needed to handle clustering)
     // _selectedMarkers.zoomToShowLayer(marker, function(){
     //     marker.openPopup();
@@ -1255,14 +1259,16 @@ function initEvents() {
     });
 
     $("#stat-skip").click(function(e){
-        if (_userId == null)
+        e.preventDefault();
+
+        if (_userId == null || !$(this).is("a"))
             return;
 
-        var skipped = $(this).data("skipped");
+        const skipped = $(this).data("skipped");
         if (!skipped && !confirm("Are you sure you want to mark this bin as skipped?"))
             return;
 
-        var payload = {
+        const payload = {
             "csrfmiddlewaretoken": _csrf,
             "bin_id": _bin,
             "skipped": skipped

--- a/ifcbdb/common/auth.py
+++ b/ifcbdb/common/auth.py
@@ -132,3 +132,16 @@ def get_associated_datasets(user, exclude_inactive=True):
         .values_list("dataset_id", flat=True)
 
     return datasets.filter(id__in=dataset_ids)
+
+def can_update_bin(user, bin):
+    if not user.is_authenticated or not bin:
+        return False
+
+    if user.is_superuser or user.is_staff:
+        return True
+
+    return Team.objects \
+        .filter(pk=bin.team_id) \
+        .filter(teamuser__user=user) \
+        .filter(teamuser__role_id__in=[TeamRoles.CAPTAIN.value, TeamRoles.MANAGER.value]) \
+        .exists()

--- a/ifcbdb/dashboard/views.py
+++ b/ifcbdb/dashboard/views.py
@@ -30,6 +30,7 @@ from .models import Dataset, Bin, Instrument, Timeline, bin_query, Tag, Comment,
     Team, TeamDataset, ReservedDatasetName
 from .forms import DatasetSearchForm
 from common.utilities import *
+from common import auth
 
 from dashboard.accession import Accession, export_metadata
 import waffle
@@ -518,12 +519,11 @@ def legacy_image_page(request, dataset_name, bin_id, image_id):
 def legacy_image_page_alt(request, bin_id, image_id):
     return _image_details(request, image_id, bin_id)
 
-def _details(request, bin_id=None, route=None, dataset_name=None, tags=None, instrument_number=None, cruise=None, bin_reset=False,
-             default_start_date=None, default_end_date=None, sample_type=None):
+def _details(request, bin_id=None, route=None, dataset_name=None, tags=None, instrument_number=None, cruise=None,
+             bin_reset=False, default_start_date=None, default_end_date=None, sample_type=None):
     if not bin_id and not dataset_name and not tags and not instrument_number and not cruise and not sample_type:
         # TODO: 404 error; don't have enough info to proceed
         pass
-
 
     bin_qs = bin_query(dataset_name=dataset_name,
         tags=tags,
@@ -559,11 +559,13 @@ def _details(request, bin_id=None, route=None, dataset_name=None, tags=None, ins
 
     team_dataset = TeamDataset.objects.filter(dataset=dataset).select_related("team").first()
     team = team_dataset.team if team_dataset else None
+    can_update_bin = auth.can_update_bin(request.user, bin)
 
     return render(request, "dashboard/bin.html", {
         "route": route,
         "can_share_page": True,
         "can_filter_page": (route == "timeline"),
+        "can_update_bin": can_update_bin,
         "dataset": dataset,
         "instrument": instrument,
         'sample_type': sample_type,

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -677,11 +677,15 @@ def app_settings(request):
 
 @require_POST
 def add_tag(request, bin_id):
-    if not auth.is_admin(request.user):
+    if not auth.can_manage_metadata(request.user):
         return HttpResponseForbidden()
 
     tag_name = request.POST.get("tag_name", "")
     bin = get_object_or_404(Bin, pid=bin_id)
+
+    if not auth.can_update_bin(request.user, bin):
+        return HttpResponseForbidden()
+
     bin.add_tag(tag_name, user=request.user)
 
     return JsonResponse({
@@ -691,11 +695,15 @@ def add_tag(request, bin_id):
 
 @require_POST
 def remove_tag(request, bin_id):
-    if not auth.is_admin(request.user):
+    if not auth.can_manage_metadata(request.user):
         return HttpResponseForbidden()
 
     tag_name = request.POST.get("tag_name", "")
     bin = get_object_or_404(Bin, pid=bin_id)
+
+    if not auth.can_update_bin(request.user, bin):
+        return HttpResponseForbidden()
+
     bin.delete_tag(tag_name)
 
     return JsonResponse({
@@ -977,13 +985,16 @@ def metadata_upload_cancel(request):
 
 @require_POST
 def toggle_skip(request):
-    if not auth.is_admin(request.user):
+    if not auth.can_manage_metadata(request.user):
         return HttpResponseForbidden()
 
     bin_id = request.POST.get("bin_id")
     skipped = request.POST.get("skipped") == "true"
 
     bin = get_object_or_404(Bin, pid=bin_id)
+    if not auth.can_update_bin(request.user, bin):
+        return HttpResponseForbidden()
+
     bin.skip = not skipped
     bin.save()
 

--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -484,7 +484,7 @@
                 <div class="pl-2">
                   <span>Tags:</span>
                     <span id="tags" ></span>
-                  {% if user.is_authenticated %}
+                  {% if can_update_bin %}
                   <a class="btn btn-sm btn-mdb-color px-2 py-1" id="add-tag"><i class="fas fa-plus"></i></a>
                   <input type="text" placeholder="tag name" id="tag-name" class="d-none" tabindex="0" />
                   <a class="btn btn-sm btn-mdb-color ml-0 d-none pt-1 pb-1 pl-2 pr-2" id="tag-confirm">
@@ -567,7 +567,11 @@
                         <div class="d-flex flex-row">
                             <div class="flex-column">
                                 Skipped:
-                                <a {% if user.is_authenticated %}href="javascript:;"{% endif %} id="stat-skip"></a>
+                                {% if can_update_bin %}
+                                    <a id="stat-skip" href="#"></a>
+                                {% else %}
+                                    <span id="stat-skip"></span>
+                                {% endif %}
                             </div>
                         </div>
                       <div class="d-flex flex-row">

--- a/ifcbdb/templates/secure/tag-management.html
+++ b/ifcbdb/templates/secure/tag-management.html
@@ -73,7 +73,6 @@
         e.preventDefault();
 
         const name = $(this).data("name");
-        console.log(name)
         if (!confirm("Are you sure you want to remove the tag named \"" + name + "\"? This will also unassign it from all bins.")) {
             return;
         }


### PR DESCRIPTION
This PR completes logic to allow managers and captains to add tags, remove tags, and update the skip flag. Previously it was visible to them but would not work because they were not logged in as a super user. The UI is also update to not display the link on the skip option, add tag button, or delete "x" next to each tag when the user is not able to do so