### PR TITLE
bump pyifcb version to 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ scikit-image==0.24.0
 pysmb==1.2.10
 pyyaml==6.0.2
 django-waffle==5.0.0
-git+https://github.com/joefutrelle/pyifcb@v1.3.0
+git+https://github.com/joefutrelle/pyifcb@v1.3.1


### PR DESCRIPTION
This version pulls in compatible versions of Pillow and requests.