### PR TITLE
fix manage links on dataset list when teams is not enabled

### DIFF
--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -140,14 +140,21 @@ def dt_datasets(request):
 
     data = []
     for dataset in datasets:
-        item = dataset.teamdataset_set.first() if is_teams_enabled else None
-        team_name = item.team.name if item else ""
+        row = {
+            "dataset_id": dataset.id,
+            "name": dataset.name,
+            "title": dataset.title,
+            "is_active": dataset.is_active,
+            "team": "",
+        }
 
-        data.append([dataset.name, dataset.title, dataset.is_active, team_name, dataset.id])
+        if is_teams_enabled:
+            item = dataset.teamdataset_set.first()
+            row["team"] = item.team.name if item else ""
 
-    return JsonResponse({
-        "data": data
-    })
+        data.append(row)
+
+    return JsonResponse({"data": data})
 
 @waffle_switch('Teams')
 def dt_teams(request):

--- a/ifcbdb/templates/secure/dataset-management.html
+++ b/ifcbdb/templates/secure/dataset-management.html
@@ -16,17 +16,7 @@
 <hr class="my-2">
 <div class="row py-2 px-3">
     <div class="col">
-        <table id="datasets" class="table table-sm table-striped table-bordered" style="width:100%">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Title</th>
-                    <th>Active?</th>
-                    {% if is_teams_enabled %}<th>Team</th>{% endif %}
-                    <th></th>
-                </tr>
-            </thead>
-        </table>
+        <table id="datasets" class="table table-sm table-striped table-bordered" style="width:100%"></table>
     </div>
 </div>
 
@@ -49,24 +39,34 @@
                 url: "{% url 'secure:datasets_dt' %}"
             },
             columns: [
-                {}, // Name
-                {}, // Description
                 {
-                    targets: 2,
-                    render: function(data, type, row) {
-                        return data ? "Yes" : "No";
-                    }
-                }, // Is Active
-                {% if is_teams_enabled %}{}, // Team{% endif %}
-                { // Edit and datasets
-                    targets: -1,
-                    render: function ( data, type, row ) {
-                        return (
-                            "<a class='btn btn-sm btn-mdb-color mr-2' href='/secure/edit-dataset/" + data + "'>" +
-                            "<i class='fas fa-edit magic mr-1'></i>Manage" +
-                            "</a>"
-                        );
-                    }
+                    title: "Name",
+                    data: "name"
+                },
+                {
+                    title: "Title",
+                    data: "title"
+                },
+                {
+                    title: "Active?",
+                    data: "is_active",
+                    render: (data) => data ? "Yes" : "No"
+                },
+                {
+                    title: "Team",
+                    data: "team",
+                    visible: "{{ is_teams_enabled }}".toLowerCase() === "true",
+                },
+                {
+                    title: "",
+                    data: "dataset_id",
+                    orderable: false,
+                    render: (data) => ((
+                        "<a class='btn btn-sm btn-mdb-color mr-2' href='/secure/edit-dataset/" + data + "'>" +
+                        "<i class='fas fa-edit magic mr-1'></i>Manage" +
+                        "</a>"
+                    ))
+
                 }
             ]
         });


### PR DESCRIPTION
This PR fixes an issue with the admin dataset list screen. When teams is not enabled, the manage links were not working due to incorrect positioning logic in the grid. The grid logic now uses more modern syntax for datatables that avoids having to target columns with indexes - this fixes the underlying issue and also makes it much easier to maintain going forward