### PR TITLE
Make action columns in metadata export optional

### DIFF
--- a/ifcbdb/dashboard/accession.py
+++ b/ifcbdb/dashboard/accession.py
@@ -560,7 +560,7 @@ def import_metadata(metadata_dataframe, progress_callback=do_nothing):
 
     return progress
 
-def export_metadata(ds, bins):
+def export_metadata(ds, bins, include_actions=False):
     # Maximum number of bins this export can return. The limit is relatively arbitrary, and in place to prevent runaway
     #   queries returning lots of data when no search parameters are defined
     max_results = 500_000
@@ -650,10 +650,12 @@ def export_metadata(ds, bins):
         r['comment_summary'].append(comment_summary_by_id.get(item['id'], ''))
         r['trigger_selection'].append(trigger_selection_by_id.get(item['id'], ''))
         r['skip'].append(1 if item['skip'] else 0)
-        r['add_dataset'].append('')
-        r['remove_dataset'].append('')
-        r['add_tag'].append('')
-        r['remove_tag'].append('')
+
+        if include_actions:
+            r['add_dataset'].append('')
+            r['remove_dataset'].append('')
+            r['add_tag'].append('')
+            r['remove_tag'].append('')
 
     df = pd.DataFrame(r)
 

--- a/ifcbdb/dashboard/views.py
+++ b/ifcbdb/dashboard/views.py
@@ -1387,6 +1387,7 @@ def export_metadata_view(request, dataset_name=None):
     start_date = request.GET.get("start_date")
     end_date = request.GET.get("end_date")
     include_skip = request.GET.get('include_skip', 'true')
+    include_actions = request.GET.get('include_actions', 'false').lower() == 'true'
 
     filter_skip = not include_skip.lower() == 'true'
 
@@ -1409,7 +1410,7 @@ def export_metadata_view(request, dataset_name=None):
         raise Http404('no bins match the given query')
 
     ds = Dataset.objects.get(name=dataset_name) if dataset_name else None
-    df = export_metadata(ds, bin_qs)
+    df = export_metadata(ds, bin_qs, include_actions)
 
     filename = (dataset_name or 'ifcb-metadata') + '.csv'
     response = dataframe_csv_response(df, index=None)

--- a/ifcbdb/secure/forms.py
+++ b/ifcbdb/secure/forms.py
@@ -454,6 +454,13 @@ class BinSearchForm(forms.Form):
     sample_type = forms.CharField(
         required=False,
         widget=forms.Select(attrs={"class": input_classes}))
+    include_actions = forms.ChoiceField(
+        required=False,
+        choices=[(False, 'Do not include'), (True, 'Include')],
+        widget=forms.Select(attrs={"class": input_classes, "style": "width:10rem"}))
+
+    def clean_include_actions(self):
+        return self.cleaned_data.get("include_actions").lower() == "true"
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user") if "user" in kwargs else None

--- a/ifcbdb/secure/views.py
+++ b/ifcbdb/secure/views.py
@@ -1150,7 +1150,7 @@ def bin_management_export(request, dataset_name=None):
         })
 
     bin_qs = build_bin_query_from_form_data(request.user, form)
-    df = export_metadata(None, bin_qs)
+    df = export_metadata(None, bin_qs, form.cleaned_data.get("include_actions"))
     filename = 'bins.csv'
 
     csv_buf = BytesIO()

--- a/ifcbdb/templates/secure/bin-management.html
+++ b/ifcbdb/templates/secure/bin-management.html
@@ -77,18 +77,40 @@
         </form>
     </div>
     <div class="col-md-4">
-        <div id="results-panel" class="d-none alert alert-info">
-            <h5>Search Results</h5>
-            <hr />
+        <div id="results-panel" class="d-none">
+            <div class="alert alert-info">
+                <h5>Search Results</h5>
+                <hr />
 
-            <p>Total Bins Found: <strong><span id="total"></span></strong></p>
+                <p>Total Bins Found: <strong><span id="total"></span></strong></p>
 
-            <button class="btn btn-sm btn-mdb-color" type="button" id="search-again">
-                <i class="fas fa-magnifying-glass"></i> Search Again
-            </button>
-            <button class="btn btn-sm btn-mdb-color" type="button" id="export-button">
-                <i class="fas fa-file-export"></i> Export Metadata
-            </button>
+                <button class="btn btn-sm btn-mdb-color" type="button" id="search-again">
+                    <i class="fas fa-magnifying-glass"></i> Search Again
+                </button>
+            </div>
+
+            <div class="alert alert-info">
+                <h5>Export Metadata</h5>
+                <hr />
+
+                <div>
+                    <label>Action Columns:</label>
+                    <button type="button" class="btn btn-link p-0 text-muted lh-1"
+                            data-toggle="tooltip" data-placement="top" aria-label="Help information"
+                            title="Including actions will add empty columns to the export file for all supported actions
+                            when uploading metadata. E.g., adding datasets, removing tags, etc.">
+                        <i class="fas fa-question-circle text-info" aria-hidden="true"></i>
+                    </button>
+                    {{ form.include_actions }}
+                </div>
+
+                <br />
+
+                <button class="btn btn-sm btn-mdb-color" type="button" id="export-button">
+                    <i class="fas fa-file-export"></i> Export Metadata
+                </button>
+            </div>
+
         </div>
     </div>
     <div class="col-md-4">
@@ -231,6 +253,14 @@
 
         function exportBins() {
             const searchFormData = buildSearchFormData();
+
+            // Add export options
+            const includeActions = $("[name=include_actions]");
+
+            searchFormData.push({
+                name: includeActions.attr("name"),
+                value: includeActions.val()
+            });
 
             $.ajax({
                 url: "/secure/bin-management/export",


### PR DESCRIPTION
This PR will make the inclusion of the action columns (add_dataset, remove_tag, etc) option when exporting from bin management or the dedicated /export API endpoint. The default will to not include those columns, so the end user needs to explicitly opt-in to those columns

The API endpoint will accept a `include_actions` querystring parameter which can be `true` or `false`. The UI on the bin management page now splits the export to a separate box, with the options (just this one) included:

<img width="951" height="547" alt="image" src="https://github.com/user-attachments/assets/713278ec-cbdd-4f4c-9a44-1ca4a14e3a4d" />
