### PR TITLE
Use absolute URLs for breadcrumb links

### DIFF
--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -14,39 +14,41 @@
         <div class="col-sm-auto">
         <div class="pl-3 d-flex flex-row flex-sm-col">
             <span class="h3-responsive">
+                {% with team_name=request.resolver_match.kwargs.team_name %}
                 {% if team %}
                     <a href="{% url 'datasets' team.name %}">{{ team.name }}</a> »
                 {% endif %}
 
                 {% if dataset %}
-                    <a href="/timeline?dataset={{ dataset.name }}">
+                    <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?dataset={{ dataset.name }}">
                       {{ dataset.title }}
                     </a>
                     {% if instrument or tags or cruise or sample_type %}» {% endif %}
                 {% endif %}
 
                 {% if cruise %}
-                    <a href="/timeline?cruise={{ cruise }}">{{ cruise }}</a>
+                    <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?cruise={{ cruise }}">{{ cruise }}</a>
                     {% if instrument or tags or sample_type %}» {% endif %}
                 {% endif %}
 
                 {% if sample_type %}
-                    <a href="/timeline?sample_type={{ sample_type }}">
+                    <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?sample_type={{ sample_type }}">
                         {{ sample_type }}
                     </a>
                    {% if instrument or tags %}» {% endif %}
                 {% endif %}
 
                 {% if instrument %}
-                    <a href="/timeline?instrument={{ instrument.number }}">
+                    <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?instrument={{ instrument.number }}">
                       IFCB{{ instrument.number }}
                     </a>
                     {% if tags %}» {% endif %}
                 {% endif %}
 
                 {% if tags %}
-                    <a href="/timeline?tags={{ tags }}">{{ tags }}</a>
+                    <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?tags={{ tags }}">{{ tags }}</a>
                 {% endif %}
+                {% endwith %}
             </span>
             <a class="d-sm-none d-inline tstabcollapser ml-auto" data-toggle="collapse" data-target="#ts-tabs" aria-expanded="false"></a>
             <span class="d-none">
@@ -114,39 +116,41 @@
     <div class="row d-flex justify-content-between">
       <div class="pl-3">
         <span class="h3-responsive">
+            {% with team_name=request.resolver_match.kwargs.team_name %}
             {% if team %}
                 <a href="{% url 'datasets' team.name %}">{{ team.name }}</a> »
             {% endif %}
 
             {% if dataset %}
-              <a href="/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
+              <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
                 {{ dataset.title }}
               </a>
             {% elif bin.primary_dataset %}
-              <a href="/timeline?dataset={{ bin.primary_dataset.name }}&bin={{ bin.pid }}">
+              <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?dataset={{ bin.primary_dataset.name }}&bin={{ bin.pid }}">
                 {{ bin.primary_dataset.title }}
               </a>
             {% endif %}
             {% if cruise %}»
-                <a href="/timeline?cruise={{ cruise }}&bin={{ bin.pid }}">
+                <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?cruise={{ cruise }}&bin={{ bin.pid }}">
                     {{ cruise }}
                 </a>
             {% endif %}
             {% if sample_type %}»
-                <a href="/timeline?sample_type={{ sample_type }}&bin={{ bin.pid }}">
+                <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?sample_type={{ sample_type }}&bin={{ bin.pid }}">
                 {{ sample_type }}
               </a>
             {% endif %}
             {% if instrument %}»
-              <a href="/timeline?instrument={{ instrument.number }}&bin={{ bin.pid }}">
+              <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?instrument={{ instrument.number }}&bin={{ bin.pid }}">
                 IFCB{{ instrument.number }}
               </a>
             {% endif %}
             {% if tags %}»
-              <a href="/timeline?tags={{ tags }}&bin={{ bin.pid }}">
+              <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?tags={{ tags }}&bin={{ bin.pid }}">
                 {{ tags }}
               </a>
             {% endif %}
+            {% endwith %}
         </span>
         <span class="h3-responsive">» {{ bin.pid }}</span>
       </div>

--- a/ifcbdb/templates/dashboard/bin.html
+++ b/ifcbdb/templates/dashboard/bin.html
@@ -19,33 +19,33 @@
                 {% endif %}
 
                 {% if dataset %}
-                    <a href="timeline?dataset={{ dataset.name }}">
+                    <a href="/timeline?dataset={{ dataset.name }}">
                       {{ dataset.title }}
                     </a>
                     {% if instrument or tags or cruise or sample_type %}» {% endif %}
                 {% endif %}
 
                 {% if cruise %}
-                    <a href="timeline?cruise={{ cruise }}">{{ cruise }}</a>
+                    <a href="/timeline?cruise={{ cruise }}">{{ cruise }}</a>
                     {% if instrument or tags or sample_type %}» {% endif %}
                 {% endif %}
 
                 {% if sample_type %}
-                    <a href="timeline?sample_type={{ sample_type }}">
+                    <a href="/timeline?sample_type={{ sample_type }}">
                         {{ sample_type }}
                     </a>
                    {% if instrument or tags %}» {% endif %}
                 {% endif %}
 
                 {% if instrument %}
-                    <a href="timeline?instrument={{ instrument.number }}">
+                    <a href="/timeline?instrument={{ instrument.number }}">
                       IFCB{{ instrument.number }}
                     </a>
                     {% if tags %}» {% endif %}
                 {% endif %}
 
                 {% if tags %}
-                    <a href="timeline?tags={{ tags }}">{{ tags }}</a>
+                    <a href="/timeline?tags={{ tags }}">{{ tags }}</a>
                 {% endif %}
             </span>
             <a class="d-sm-none d-inline tstabcollapser ml-auto" data-toggle="collapse" data-target="#ts-tabs" aria-expanded="false"></a>
@@ -119,31 +119,31 @@
             {% endif %}
 
             {% if dataset %}
-              <a href="timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
+              <a href="/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
                 {{ dataset.title }}
               </a>
             {% elif bin.primary_dataset %}
-              <a href="timeline?dataset={{ bin.primary_dataset.name }}&bin={{ bin.pid }}">
+              <a href="/timeline?dataset={{ bin.primary_dataset.name }}&bin={{ bin.pid }}">
                 {{ bin.primary_dataset.title }}
               </a>
             {% endif %}
             {% if cruise %}»
-                <a href="timeline?cruise={{ cruise }}&bin={{ bin.pid }}">
+                <a href="/timeline?cruise={{ cruise }}&bin={{ bin.pid }}">
                     {{ cruise }}
                 </a>
             {% endif %}
             {% if sample_type %}»
-                <a href="timeline?sample_type={{ sample_type }}&bin={{ bin.pid }}">
+                <a href="/timeline?sample_type={{ sample_type }}&bin={{ bin.pid }}">
                 {{ sample_type }}
               </a>
             {% endif %}
             {% if instrument %}»
-              <a href="timeline?instrument={{ instrument.number }}&bin={{ bin.pid }}">
+              <a href="/timeline?instrument={{ instrument.number }}&bin={{ bin.pid }}">
                 IFCB{{ instrument.number }}
               </a>
             {% endif %}
             {% if tags %}»
-              <a href="timeline?tags={{ tags }}&bin={{ bin.pid }}">
+              <a href="/timeline?tags={{ tags }}&bin={{ bin.pid }}">
                 {{ tags }}
               </a>
             {% endif %}

--- a/ifcbdb/templates/dashboard/image.html
+++ b/ifcbdb/templates/dashboard/image.html
@@ -5,11 +5,13 @@
 <div class="row d-flex justify-content-between">
     <div class="col">
         <span class="h3-responsive">
+            {% with team_name=request.resolver_match.kwargs.team_name %}
             {% if dataset %}
-                <a href="/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
+                <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
                 {{ dataset.title }}</a> »
             {% endif %}
-            <a id="bin-link" href="/bin?bin={{ bin.pid }}{% if dataset %}&dataset={{ dataset.name }}{% endif %}">{{ bin.pid }}</a> » <span id="image-crumb">{{ image_id }}</span>
+            <a id="bin-link" href="{% if team_name %}/t/{{ team_name }}{% endif %}/bin?bin={{ bin.pid }}{% if dataset %}&dataset={{ dataset.name }}{% endif %}">{{ bin.pid }}</a> » <span id="image-crumb">{{ image_id }}</span>
+            {% endwith %}
         </span>
     </div>
     <div class="col">

--- a/ifcbdb/templates/dashboard/image.html
+++ b/ifcbdb/templates/dashboard/image.html
@@ -6,10 +6,10 @@
     <div class="col">
         <span class="h3-responsive">
             {% if dataset %}
-                <a href="timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
+                <a href="/timeline?dataset={{ dataset.name }}&bin={{ bin.pid }}">
                 {{ dataset.title }}</a> »
             {% endif %}
-            <a id="bin-link" href="bin?bin={{ bin.pid }}{% if dataset %}&dataset={{ dataset.name }}{% endif %}">{{ bin.pid }}</a> » <span id="image-crumb">{{ image_id }}</span>
+            <a id="bin-link" href="/bin?bin={{ bin.pid }}{% if dataset %}&dataset={{ dataset.name }}{% endif %}">{{ bin.pid }}</a> » <span id="image-crumb">{{ image_id }}</span>
         </span>
     </div>
     <div class="col">

--- a/ifcbdb/templates/dashboard/list.html
+++ b/ifcbdb/templates/dashboard/list.html
@@ -8,17 +8,17 @@
     <span class="h3-responsive">
       <a href="/dashboard">Home</a>
       {% if dataset %}»
-        <a href="timeline?dataset={{ dataset.name }}">
+        <a href="/timeline?dataset={{ dataset.name }}">
           {{ dataset.title }}
         </a>
       {% endif %}
       {% if instrument_number %}»
-        <a href="timeline?instrument={{ instrument_number }}">
+        <a href="/timeline?instrument={{ instrument_number }}">
           IFCB{{ instrument_number }}
         </a>
       {% endif %}
       {% if tags %}»
-        <a href="timeline?tags={{ tags }}">
+        <a href="/timeline?tags={{ tags }}">
           {{ tags }}
         </a>
       {% endif %}

--- a/ifcbdb/templates/dashboard/list.html
+++ b/ifcbdb/templates/dashboard/list.html
@@ -6,22 +6,24 @@
 
 <div class="pl-3">
     <span class="h3-responsive">
+      {% with team_name=request.resolver_match.kwargs.team_name %}
       <a href="/dashboard">Home</a>
       {% if dataset %}»
-        <a href="/timeline?dataset={{ dataset.name }}">
+        <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?dataset={{ dataset.name }}">
           {{ dataset.title }}
         </a>
       {% endif %}
       {% if instrument_number %}»
-        <a href="/timeline?instrument={{ instrument_number }}">
+        <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?instrument={{ instrument_number }}">
           IFCB{{ instrument_number }}
         </a>
       {% endif %}
       {% if tags %}»
-        <a href="/timeline?tags={{ tags }}">
+        <a href="{% if team_name %}/t/{{ team_name }}{% endif %}/timeline?tags={{ tags }}">
           {{ tags }}
         </a>
       {% endif %}
+      {% endwith %}
     </span>
     <a id="view-timeline" class="pl-3 my-auto" href="#"title="View Timeline" Style="color:#59698d" data-toggle="tooltip" data-placement="bottom"><i class="fas h3-responsive fa-chart-line"></i></a>
     <span class="d-none">


### PR DESCRIPTION
This PR changes the URLs for all breadcrumb links to use a leading slash for the breadcrumb URLs, which fixes errors when a user lands on the page via one of the legacy URLs. E.g., https://localhost:8443/armstrong/D20220412T152910_IFCB115_01235.html. it will also handle retaining the `/t/{team}` prefix when present

